### PR TITLE
Fix parsing of booleans

### DIFF
--- a/JSON/JSON.swift
+++ b/JSON/JSON.swift
@@ -130,7 +130,7 @@ public enum JSON : Equatable, Printable {
                 self = .JSONString(string)
                 
             case let number as NSNumber:
-                if number.objCType == "c" {
+                if String.fromCString(number.objCType) == "c" {
                     self = .JSONBool(number.boolValue)
                 }
                 else {
@@ -220,11 +220,6 @@ public enum JSON : Equatable, Printable {
         case .JSONBool(let value):
             return value
             
-        // there seems to be an issue with the NSJSONSerialization and types going across the boundary...
-        // The bool values are not differentiable from numbers...
-        case .JSONNumber(let value):
-            return value == 0
-
         default:
             return nil
         }


### PR DESCRIPTION
The
  number.objCType == "c"
didn't work properly.

PS: The value==0 check was actually inverted. Should have been value!=0, as far as I can see. No idea why the tests succeeded...?
