### PR TITLE
Improve subscript syntax

### DIFF
--- a/JSON/JSON.swift
+++ b/JSON/JSON.swift
@@ -246,24 +246,28 @@ public enum JSON : Equatable, Printable {
     }
 
     /// Attempts to treat the `JSONValue` as a dictionary and return the item with the given key.
-    public subscript(key: String) -> JSONValue? {
+    public subscript(key: String) -> JSONValue {
         switch self {
         case .JSONObject(let dict):
-            return dict[key]
+            if let result = dict[key] {
+                return result
+            } else {
+                return JSONNull
+            }
             
         default:
-            return nil
+            return JSONNull
         }
     }
 
     /// Attempts to treat the `JSONValue` as an array and return the item at the index.
-    public subscript(index: Int) -> JSONValue? {
+    public subscript(index: Int) -> JSONValue {
         switch self {
         case .JSONArray(let array):
             return array[index]
             
         default:
-            return nil
+            return JSONNull
         }
     }
     

--- a/JSONTests/JSONTests.swift
+++ b/JSONTests/JSONTests.swift
@@ -196,11 +196,11 @@ class JSONTests: XCTestCase {
             ]
         ]
         
-        XCTAssertTrue(json["stat"]?.string! == "ok")
-        XCTAssertTrue(json["blogs"]?["blog"] != nil)
+        XCTAssertTrue(json["stat"].string! == "ok")
+        XCTAssertTrue(json["blogs"]["blog"] != nil)
   
-        XCTAssertTrue(json["blogs"]?["blog"]?[0]?["id"]?.number! == 73)
-        XCTAssertTrue(json["blogs"]?["blog"]?[0]?["needspassword"]?.bool!)
+        XCTAssertTrue(json["blogs"]["blog"][0]["id"].number! == 73)
+        XCTAssertTrue(json["blogs"]["blog"][0]["needspassword"].bool!)
     }
     
     func testFlickrWithDictAnyObjectResult() {
@@ -226,11 +226,11 @@ class JSONTests: XCTestCase {
         
         var json = JSON(flickr)
         
-        XCTAssertTrue(json["stat"]?.string! == "ok")
-        XCTAssertTrue(json["blogs"]?["blog"] != nil)
+        XCTAssertTrue(json["stat"].string! == "ok")
+        XCTAssertTrue(json["blogs"]["blog"] != nil)
         
-        XCTAssertTrue(json["blogs"]?["blog"]?[0]?["id"]?.number! == 73)
-        XCTAssertTrue(json["blogs"]?["blog"]?[0]?["needspassword"]?.bool!)
+        XCTAssertTrue(json["blogs"]["blog"][0]["id"].number! == 73)
+        XCTAssertTrue(json["blogs"]["blog"][0]["needspassword"].bool!)
     }
     
     func testFlickrResultWithNSTypes() {
@@ -240,11 +240,11 @@ class JSONTests: XCTestCase {
         if let dict = flickr as? NSDictionary {
             var json = JSON(dict)
             
-            XCTAssertTrue(json["stat"]?.string! == "ok")
-            XCTAssertTrue(json["blogs"]?["blog"] != nil)
+            XCTAssertTrue(json["stat"].string! == "ok")
+            XCTAssertTrue(json["blogs"]["blog"] != nil)
             
-            XCTAssertTrue(json["blogs"]?["blog"]?[0]?["id"]?.number! == 73)
-            XCTAssertTrue(json["blogs"]?["blog"]?[0]?["needspassword"]?.bool!)
+            XCTAssertTrue(json["blogs"]["blog"][0]["id"].number! == 73)
+            XCTAssertTrue(json["blogs"]["blog"][0]["needspassword"].bool!)
         }
         else {
             XCTFail("The JSON object should have been a dictionary.")
@@ -256,11 +256,11 @@ class JSONTests: XCTestCase {
 
         var parsedJson = JSON.parse(String)
         if let json = parsedJson {
-            XCTAssertTrue(json["stat"]?.string! == "ok")
-            XCTAssertTrue(json["blogs"]?["blog"] != nil)
+            XCTAssertTrue(json["stat"].string! == "ok")
+            XCTAssertTrue(json["blogs"]["blog"] != nil)
             
-            XCTAssertTrue(json["blogs"]?["blog"]?[0]?["id"]?.number! == 73)
-            XCTAssertTrue(json["blogs"]?["blog"]?[0]?["needspassword"]?.bool!)
+            XCTAssertTrue(json["blogs"]["blog"][0]["id"].number! == 73)
+            XCTAssertTrue(json["blogs"]["blog"][0]["needspassword"].bool!)
         }
         else {
             XCTFail()


### PR DESCRIPTION
In the Swift forum you wrote "Con: Syntax is still no where as clean as ObjC, though it is type-safe now..." (https://devforums.apple.com/message/1011703#1011703).

I hope this change fixes that.

PS: As the unit tests failed (due to inverted value==0 check), I had to include the pull request that fixes that too.
