### PR TITLE
Fix my own bug in prettyPrinting output; add test case which would have caught it

### DIFF
--- a/src/JSValue.swift
+++ b/src/JSValue.swift
@@ -249,10 +249,10 @@ extension JSValue {
             return "\"\(escaped)\""
             
         case .JSArray(let array):
-            return (array.map({ "\(nextIndent)\($0.prettyPrint(indent, level + 1))" })).joinWithSeparator("[\(newline)" + ",\(newline)") + "\(newline)\(currentIndent)]"
+            return "[\(newline)" + (array.map({ "\(nextIndent)\($0.prettyPrint(indent, level + 1))" })) .joinWithSeparator(",\(newline)") + "\(newline)\(currentIndent)]"
             
         case .JSObject(let dict):
-            return "{" + (dict.map({ "\(nextIndent)\"\($0)\":\(space)\($1.prettyPrint(indent, level + 1))"})).joinWithSeparator("{\(newline)" + ",\(newline)") + "\(newline)\(currentIndent)}"
+            return "{\(newline)" + (dict.map({ "\(nextIndent)\"\($0.stringByReplacingOccurrencesOfString("\"", withString: "\\\""))\":\(space)\($1.prettyPrint(indent, level + 1))"})).joinWithSeparator(",\(newline)") + "\(newline)\(currentIndent)}"
             
         case .JSNull:
             return "null"

--- a/tests/JSValueTests.Parsing.swift
+++ b/tests/JSValueTests.Parsing.swift
@@ -336,6 +336,20 @@ class JSValueParsingTests : XCTestCase {
         }
     }
     
+    func testParsePrettyPrintedNestedMixedTypes() {
+        let string = "{\"key1\": 1, \"key2\": [        -12 , 12        ], \"key3\": \"Bob\", \"\\n鱿aK㝡␒㼙2촹f\": { 'foo': 'bar' }, \"key5\": false, \"key6\": null, \"key\\\"7\": -2.11234123}"
+        let json1 = JSON.parse(string)
+        
+        XCTAssertTrue(json1.error == nil, json1.error?.userInfo?.description ?? "No error info")
+        
+        let prettyPrinted = json1.value!.stringify()
+        print(prettyPrinted)
+        let json2 = JSON.parse(prettyPrinted)
+        
+        XCTAssertTrue(json2.error == nil, json2.error?.userInfo?.description ?? "No error info")
+        XCTAssertEqual(json1.value!, json2.value!)
+    }
+    
     func testMutipleNestedArrayDictionaryTypes() {
         let string = "[[[[{},{},{\"ꫯ\":\"ꫯ\"}]]],[],[],[{}]]"
         let json = JSON.parse(string)


### PR DESCRIPTION
I introduced a bug in prettyPrinting during my previous pull request #43 that results in invalid JSON. @potmo opened two issues #45 and #46 with solutions, so I implemented those directly.

I then created a test case which takes a JSON string, parses it, prettyPrints it, then re-parses it and compares it to the source. In doing so I found a small error in @potmo's code so fixed that too.

Tests pass. Sorry for breaking your repo.