### PR TITLE
Code style changes to remove warnings in Xcode 7.3.1

### DIFF
--- a/src/JSValue.Parsing.swift
+++ b/src/JSValue.Parsing.swift
@@ -521,11 +521,11 @@ extension JSValue {
     static func contextualString<S: SequenceType where S.Generator.Element == UInt8>(generator: ReplayableGenerator<S>, left: Int = 5, right: Int = 10) -> String {
         var string = ""
 
-        for var i = left; i > 0; i-- {
+        for _ in 0..<left {
             generator.replay()
         }
 
-        for var i = 0; i < (left + right); i++ {
+        for _ in 0..<(left + right) {
             let codeunit = generator.next() ?? 0
             string += String(codeunit)
         }

--- a/tests/JSValueTests.Usage.swift
+++ b/tests/JSValueTests.Usage.swift
@@ -135,11 +135,11 @@ class JSValueUsageTests : XCTestCase {
                 "url" : "http://remote.bloxus.com/"
             ]
         
-        let blog = make(
-            (json["id"].number ⇒ toInt),
-            json["name"].string,
-            json["needspassword"].bool,
-            (json["url"].string ⇒ toURL))
+        let blog = make ⇒
+            (json["id"].number ⇒ toInt) ⇒
+            json["name"].string ⇒
+            json["needspassword"].bool ⇒
+            (json["url"].string ⇒ toURL)
         
         XCTAssertTrue(blog != nil)
         
@@ -164,7 +164,7 @@ class JSValueUsageTests : XCTestCase {
         let password = json["needspassword"] ⇒ toBool
         let url = json["url"] ⇒ toURL
         
-        _ = makeFailable(id, name, password, url)
+        _ = makeFailable ⇒ id ⇒ name ⇒ password ⇒ url
         
 //        XCTAssertTrue(blog.1 != nil)
 //        if let error = blog.1 {
@@ -243,7 +243,10 @@ func toURL(string: String?) -> NSURL? {
     return nil
 }
 
-func make(id: Int?, _ name: String?, _ needsPassword: Bool?, _ url: NSURL?) -> Blog?
+func make(id: Int?)
+    (name: String?)
+    (needsPassword: Bool?)
+    (url: NSURL?) -> Blog?
 {
     if id == nil { return nil }
     if name == nil { return nil }
@@ -253,8 +256,10 @@ func make(id: Int?, _ name: String?, _ needsPassword: Bool?, _ url: NSURL?) -> B
     return Blog(id: id!, name: name!, needsPassword: needsPassword!, url: url!)
 }
 
-func makeFailable(id: (Int?, Error?), _ name: (String?, Error?),
-                  _ needsPassword: (Bool?, Error?), _ url: (NSURL?, Error?)) -> (Blog?, Error?)
+func makeFailable(id: (Int?, Error?))
+    (_ name: (String?, Error?))
+    (_ needsPassword: (Bool?, Error?))
+    (_ url: (NSURL?, Error?)) -> (Blog?, Error?)
 {
     if let error = id.1 { return (nil, error) }
     if let error = name.1 { return (nil, error) }

--- a/tests/JSValueTests.Usage.swift
+++ b/tests/JSValueTests.Usage.swift
@@ -135,11 +135,11 @@ class JSValueUsageTests : XCTestCase {
                 "url" : "http://remote.bloxus.com/"
             ]
         
-        let blog = make ⇒
-            (json["id"].number ⇒ toInt) ⇒
-            json["name"].string ⇒
-            json["needspassword"].bool ⇒
-            (json["url"].string ⇒ toURL)
+        let blog = make(
+            (json["id"].number ⇒ toInt),
+            json["name"].string,
+            json["needspassword"].bool,
+            (json["url"].string ⇒ toURL))
         
         XCTAssertTrue(blog != nil)
         
@@ -164,7 +164,7 @@ class JSValueUsageTests : XCTestCase {
         let password = json["needspassword"] ⇒ toBool
         let url = json["url"] ⇒ toURL
         
-        _ = makeFailable ⇒ id ⇒ name ⇒ password ⇒ url
+        _ = makeFailable(id, name, password, url)
         
 //        XCTAssertTrue(blog.1 != nil)
 //        if let error = blog.1 {
@@ -243,10 +243,7 @@ func toURL(string: String?) -> NSURL? {
     return nil
 }
 
-func make(id: Int?)
-    (name: String?)
-    (needsPassword: Bool?)
-    (url: NSURL?) -> Blog?
+func make(id: Int?, _ name: String?, _ needsPassword: Bool?, _ url: NSURL?) -> Blog?
 {
     if id == nil { return nil }
     if name == nil { return nil }
@@ -256,10 +253,8 @@ func make(id: Int?)
     return Blog(id: id!, name: name!, needsPassword: needsPassword!, url: url!)
 }
 
-func makeFailable(id: (Int?, Error?))
-    (_ name: (String?, Error?))
-    (_ needsPassword: (Bool?, Error?))
-    (_ url: (NSURL?, Error?)) -> (Blog?, Error?)
+func makeFailable(id: (Int?, Error?), _ name: (String?, Error?),
+                  _ needsPassword: (Bool?, Error?), _ url: (NSURL?, Error?)) -> (Blog?, Error?)
 {
     if let error = id.1 { return (nil, error) }
     if let error = name.1 { return (nil, error) }

--- a/tests/JSValueTests.Usage.swift
+++ b/tests/JSValueTests.Usage.swift
@@ -244,29 +244,43 @@ func toURL(string: String?) -> NSURL? {
 }
 
 func make(id: Int?)
-    (name: String?)
-    (needsPassword: Bool?)
-    (url: NSURL?) -> Blog?
+    -> String?
+    -> Bool?
+    -> NSURL?
+    -> Blog?
 {
-    if id == nil { return nil }
-    if name == nil { return nil }
-    if needsPassword == nil { return nil }
-    if url == nil { return nil }
-    
-    return Blog(id: id!, name: name!, needsPassword: needsPassword!, url: url!)
+    return { name in
+        return { needsPassword in
+            return { url in
+                if id == nil { return nil }
+                if name == nil { return nil }
+                if needsPassword == nil { return nil }
+                if url == nil { return nil }
+                
+                return Blog(id: id!, name: name!, needsPassword: needsPassword!, url: url!)
+            }
+        }
+    }
 }
 
 func makeFailable(id: (Int?, Error?))
-    (_ name: (String?, Error?))
-    (_ needsPassword: (Bool?, Error?))
-    (_ url: (NSURL?, Error?)) -> (Blog?, Error?)
+    -> (String?, Error?)
+    -> (Bool?, Error?)
+    -> (NSURL?, Error?)
+    -> (Blog?, Error?)
 {
-    if let error = id.1 { return (nil, error) }
-    if let error = name.1 { return (nil, error) }
-    if let error = needsPassword.1 { return (nil, error) }
-    if let error = url.1 { return (nil, error) }
-    
-    return (Blog(id: id.0!, name: name.0!, needsPassword: needsPassword.0!, url: url.0!), nil)
+    return { name in
+        return { needsPassword in
+            return { url in
+                if let error = id.1 { return (nil, error) }
+                if let error = name.1 { return (nil, error) }
+                if let error = needsPassword.1 { return (nil, error) }
+                if let error = url.1 { return (nil, error) }
+                
+                return (Blog(id: id.0!, name: name.0!, needsPassword: needsPassword.0!, url: url.0!), nil)
+            }
+        }
+    }
 }
 
 func toInt(value: JSValue) -> (Int?, Error?) {


### PR DESCRIPTION
Changed a couple of loops to use for-in syntax, and switched one of the test functions to use regular parameter syntax (instead of curried syntax)